### PR TITLE
Update DeviceController.php

### DIFF
--- a/Controller/DeviceController.php
+++ b/Controller/DeviceController.php
@@ -173,6 +173,7 @@ class DeviceController extends Controller
         $device->setAppVersion($appVersion);
         $device->setAppId($appId);
         $device->setState(Device::STATE_PRODUCTION);
+        $device->setStatus(DeviceStatus::DEVICE_STATUS_ACTIVE);
         $deviceManager->saveDevice($device);
 
         return null;


### PR DESCRIPTION
When a GCM Device is initially registered it's status is set to active, if you unregister it, the status gets set to inactive, however re registering does not reset the status to active.